### PR TITLE
Split I/O from TM computation

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <iostream>
+#include <iomanip>
 #include <sstream>
 #include <numeric>
 #include <cmath>
@@ -15,47 +16,75 @@
 #include "turingMachine.h"
 #include "parseArgs.h"
 
+/** Evaluate all relative turing machine programs with the given architecture.
+ *
+ * @param states
+ * @param alphabet_size
+ * @param num_iterations
+ * @param k
+ * @param verbose
+ * @return a vector of normalized compression values, one per turing machine
+ */
+std::vector<double> tm(
+    size_t states,
+    size_t alphabet_size,
+    unsigned int num_iterations,
+    unsigned int k,
+    bool verbose) {
+  TuringMachine machine(states, alphabet_size);
+  std::vector <double> avg_nc_results;
+  bool normalizer = true;
+  NormalizedCompressionMarkovTable normalizedCompressionMarkovTable(k , alphabet_size);
+
+  unsigned int counter = 0;  
+  do { 
+    machine.reset_tape_and_state();
+    for (auto i = 0u; i < num_iterations -1 ; ++i){
+      normalizedCompressionMarkovTable.mrkvTable.reset();
+      machine.act(); //importante ser antes
+    }
+    double normalizedCompressionValue = normalizedCompressionMarkovTable.update_nc_mk_table(machine.turingTape, normalizer);
+    avg_nc_results.push_back(normalizedCompressionValue);
+
+    if (verbose && counter % 65536 == 0) {
+      std::cerr << "TM #" << std::setw(8) << counter << ": ncv = " << normalizedCompressionValue << "\r";
+    }
+    counter += 1;
+    normalizedCompressionMarkovTable.mrkvTable.reset();
+  } while (machine.stMatrix.next());
+  if (verbose) {
+    std::cerr << std::endl;
+  }
+  return avg_nc_results;
+}
+
 /*
   * It will iterate through all the lines in file and
   * put them in given vector
 */
 
-
 int main (int argc, char **argv){
 
   Args argument = parseArgs(argc,argv);
 
-  double NormalizedCompressionValue;
-  TuringMachine machine(argument.states, argument.alphabet_size);
-  float mean;
-  double stdev;
-  double sq_sum;
-  std::vector <double> avg_nc_results;
-  unsigned int counter = 0;
-  bool normalizer = true;
-  std::cout<< "TM \t k value \t iterations \t Compression Value " << std::endl; 
-  std::cout<< "-------------------------------------------------" <<std::endl;    
-  NormalizedCompressionMarkovTable normalizedCompressionMarkovTable(argument.k , argument.alphabet_size);
-  counter = 0;
+  auto avg_nc_results = tm(
+    argument.states,
+    argument.alphabet_size,
+    argument.numIt,
+    argument.k,
+    argument.verbose);
 
-  do {
-    //machine.stMatrix.print();    
-    machine.reset_tape_and_state();
-    for (auto i = 0u; i < argument.numIt -1 ; ++i){
-      normalizedCompressionMarkovTable.mrkvTable.reset();
-      machine.act(); //importante ser antes
-    }
-    NormalizedCompressionValue = normalizedCompressionMarkovTable.update_nc_mk_table(machine.turingTape,normalizer);
-    avg_nc_results.push_back(NormalizedCompressionValue);
-    std::cout << ++counter << "\t" << argument.k << "\t" << argument.numIt << "\t" <<  NormalizedCompressionValue << std::endl;
-    normalizedCompressionMarkovTable.mrkvTable.reset();
-  } while (machine.stMatrix.next());
-  
-  std::cout<< "-------------------------------------------------" <<std::endl;    
-  mean = std::accumulate( avg_nc_results.begin(), avg_nc_results.end(), 0.0)/avg_nc_results.size(); 
-  sq_sum = std::inner_product(avg_nc_results.begin(), avg_nc_results.end(), avg_nc_results.begin(), 0.0);
-  stdev = std::sqrt(sq_sum / avg_nc_results.size() - mean * mean);
-  std::cout<< "Number of TM \t Mean \t Standard deviation" << std::endl; 
+  std::cout<< "TM \t k value \t iterations \t Compression Value " << std::endl;
+  std::cout<< "-------------------------------------------------" <<std::endl;
+
+  for (auto i = 0u; i < avg_nc_results.size(); ++i) {
+    std::cout << (i + 1) << "\t" << argument.k << "\t" << argument.numIt << "\t" << avg_nc_results[i] << std::endl;
+  }
+
+  std::cout<< "-------------------------------------------------" <<std::endl;
+  float mean = std::accumulate( avg_nc_results.begin(), avg_nc_results.end(), 0.0)/avg_nc_results.size();
+  double sq_sum = std::inner_product(avg_nc_results.begin(), avg_nc_results.end(), avg_nc_results.begin(), 0.0);
+  double stdev = std::sqrt(sq_sum / avg_nc_results.size() - mean * mean);
+  std::cout<< "Number of TM \t Mean \t Standard deviation" << std::endl;
   std::cout << avg_nc_results.size() << "\t" << mean << "\t" << stdev << std::endl;
 }
-

--- a/src/parseArgs.cpp
+++ b/src/parseArgs.cpp
@@ -6,7 +6,7 @@
 
 
 Args parseArgs (int argc, char **argv){
-    Args argument{0,0,0,0,0};    
+    Args argument{0, 0 ,0, 0, 0, false};    
     int c;
     opterr = 0;
 
@@ -139,8 +139,10 @@ Args parseArgs (int argc, char **argv){
         }
     }
 
-    if (verbose_flag)
+    if (verbose_flag) {
         std::cerr << "verbose flag is set" << std::endl;
+        argument.verbose = true;
+    }
 
     if (optind < argc)
     {

--- a/src/parseArgs.h
+++ b/src/parseArgs.h
@@ -7,6 +7,7 @@ struct Args{
     double threshold;
     unsigned int numIt;
     unsigned int k;
+    bool verbose;
 };
 
 Args parseArgs (int argc, char **argv);


### PR DESCRIPTION
- add `verbose` flag to `Args`
- move TM stuff in `main` to a separate function
- output to stdout only when it ends 
- use `verbose` to provide feedback via stderr

Please double-check whether the documentation of `tm` is OK. I might move this function to a separate file soon.