### PR TITLE
Turing Machine ID calculation methods

### DIFF
--- a/src/markovTable.h
+++ b/src/markovTable.h
@@ -30,7 +30,7 @@ struct Metrics{
 struct CompressionResultsData
 {
   // Integer
-  std::vector <unsigned long long> tmNumber;
+  std::vector <TmId> tmNumber;
   std::vector <unsigned int> amplitude;
   std::vector <double> normalized_compression;
   std::vector <double> self_compression;

--- a/src/parseArgs.cpp
+++ b/src/parseArgs.cpp
@@ -341,7 +341,7 @@ Args parseArgs (int argc, char **argv){
     printf ("states = %zu, alphabet_size = %zu, number of iterations = %u , k = %d\n",
     argument.states, argument.alphabet_size, argument.numIt, argument.k);
 
-    if(ipow(argument.alphabet_size,argument.k) >= ipow(2,28))
+    if(ipow<unsigned long long>(argument.alphabet_size, argument.k) >= ipow<unsigned long long>(2,28))
     {
         fprintf (stderr, "k/context (%d) and Alphabet size/a (%zu) is too large..\n", argument.k, argument.alphabet_size);
         fprintf (stderr, " please consider a size of a^k (%zu^%d) smaller than 2^28..\n", argument.alphabet_size,argument.k);

--- a/src/tm.cpp
+++ b/src/tm.cpp
@@ -30,6 +30,18 @@ Metrics run_machine(TuringMachine& machine, NormalizedCompressionMarkovTable& no
 /// The RNG engine for sampling random numbers in Monte Carlo.
 using Rng = std::minstd_rand;
 
+/** Calculate the full cardinality of all possible turing machine state matrices.
+ * @param states the state cardinality
+ * @param alphabet_size the alphabet's size
+ */
+TmId tm_cardinality(unsigned int states, unsigned int alphabet_size) {
+    TmId nstates = states;
+    TmId nalphabet = alphabet_size;
+    auto record_cardinality = nstates * nalphabet * 3;
+
+    return ipow(record_cardinality, nstates * nalphabet);
+}
+
 /** Evaluate all relative turing machine programs with the given architecture.
  *
  * @param states
@@ -122,7 +134,7 @@ void tm_dynamical_profile(
     size_t alphabet_size,
     unsigned int num_iterations,
     unsigned int k,
-    unsigned long long tm_number,
+    TmId tm_number,
     unsigned int divison)
   {
 
@@ -156,7 +168,7 @@ void tm_print(
     size_t states,
     size_t alphabet_size,
     unsigned int num_iterations,
-    unsigned long long tm_number)
+    TmId tm_number)
     {
     
     TuringMachine machine(states, alphabet_size);    
@@ -174,7 +186,7 @@ void tm_profile(
     size_t alphabet_size,
     unsigned int num_iterations,
     unsigned int k,
-    unsigned long long tm_number,
+    TmId tm_number,
     unsigned int divison)
     {
 

--- a/src/tm.h
+++ b/src/tm.h
@@ -47,7 +47,7 @@ void tm_print(
     size_t states,
     size_t alphabet_size,
     unsigned int num_iterations,
-    unsigned long long tm_number);
+    TmId tm_number);
 
 
 
@@ -64,7 +64,7 @@ void tm_print(
     size_t alphabet_size,
     unsigned int num_iterations,
     unsigned int k,
-    unsigned long long tm_number,
+    TmId tm_number,
     unsigned int divison=5);
 
 
@@ -81,7 +81,7 @@ void tm_print(
     size_t alphabet_size,
     unsigned int num_iterations,
     unsigned int k,
-    unsigned long long tm_number,
+    TmId tm_number,
     unsigned int divison=5);
 
 

--- a/src/turingMachine.h
+++ b/src/turingMachine.h
@@ -8,6 +8,8 @@
 
 using std::uniform_int_distribution;
 
+using TmId = unsigned long long;
+using RecordId = unsigned int;
 using State = unsigned int;
 using Char = unsigned int;
 using Move = unsigned int;
@@ -23,21 +25,23 @@ struct TuringRecord{
   Move move;
   State state;
 
-  bool next(size_t number_of_states, size_t alphabet_size);
+  bool next(unsigned int number_of_states, unsigned int alphabet_size);
 
-  static TuringRecord by_index(unsigned long long id, size_t number_of_states, size_t alphabet_size);
+  static TuringRecord by_index(RecordId id, unsigned int number_of_states, unsigned int alphabet_size);
 };
 
 std::ostream& operator<<( std::ostream& o, const TuringRecord& r);
 
 struct StateMatrix{
   std::vector<TuringRecord> v;
-  size_t nbStates;
-  size_t alphSz;
+  unsigned int nbStates;
+  unsigned int alphSz;
 
-  StateMatrix(size_t number_of_states, size_t alphabet_size);
+  StateMatrix(unsigned int number_of_states, unsigned int alphabet_size);
 
-  void set_by_index(unsigned long long id);
+  void set_by_index(TmId id);
+
+  TmId calculate_index() const;
 
   /// Reset the state matrix into a uniformly random position.
   template<typename R>
@@ -85,7 +89,7 @@ struct TuringMachine {
   Tape turingTape;
   StateMatrix stMatrix;
 
-  TuringMachine(size_t number_of_states, size_t alphabet_size);
+  TuringMachine(unsigned int number_of_states, unsigned int alphabet_size);
   void reset_tape_and_state();
   TapeMoves act();
 };

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -3,26 +3,6 @@
 
 #include "util.h"
 
-unsigned long long ipow(unsigned long long base, unsigned long long exp) {
-    if (exp == 0) {
-      return 1;
-    }
-    if (exp == 1) {
-      return base;
-    }
-    int result = 1;
-    for (;;)
-    {
-        if (exp & 1)
-            result *= base;
-        exp >>= 1;
-        if (!exp)
-            break;
-        base *= base;
-    }
-    return result;
-}
-
 #define MAX 100000 
 
 int multiply(int x, int res[], int res_size) { 
@@ -63,21 +43,6 @@ void power(int x, int n)
   for (int i = res_size - 1; i >= 0; i--) 
       std::cout << res[i]; 
 } 
-
-
-
-/////
-
-
-/// Calculate the full cardinality of all possible turing machine state matrices
-  unsigned long long tm_cardinality(size_t states, size_t alphabet_size) {
-    
-    unsigned long long nstates = states;
-    unsigned long long nalphabet = alphabet_size;
-    auto record_cardinality = nstates * nalphabet * 3;
-
-    return ipow(record_cardinality, nstates * nalphabet);
-}
 
 /// Calculate the full cardinality of all possible turing machine state matrices
   void tm_fl_cardinality(size_t states, size_t alphabet_size) {

--- a/src/util.h
+++ b/src/util.h
@@ -3,20 +3,32 @@
 
 
 /**
-    Returns int base raised to the power of an int exponent.
+    Returns integer base raised to the power of an integer exponent.
 
     @param base. int of the base.
     @param exp. int of the exponent.
     @return int base raised to the power of an int exponent.
 */
-unsigned long long ipow(unsigned long long base, unsigned long long exp);
-
-/** Calculate the full cardinality of all possible turing machine state matrices.
- * @param states the state cardinality
- * @param alphabet_size the alphabet's size
- */
-unsigned long long tm_cardinality(size_t states, size_t alphabet_size);
-
+template <typename T>
+T ipow(T base, T exp) {
+    if (exp == 0) {
+      return 1;
+    }
+    if (exp == 1) {
+      return base;
+    }
+    T result = 1;
+    for (;;)
+    {
+        if (exp & 1)
+            result *= base;
+        exp >>= 1;
+        if (!exp)
+            break;
+        base *= base;
+    }
+    return result;
+}
 
 /** Calculate the number of turing machines with the increase in number of states.
  * @param max_number_states the number of states cardinality


### PR DESCRIPTION
- add `StateMatrix::calculate_id()`
- add `TmId` and `RecordId` alias types
- make `ipow` generic over integer types, fixes restrictive bug
- move `tm_cardinality` to tm.cpp